### PR TITLE
Fix incorrect order of $ionicUser injection.

### DIFF
--- a/ionic-core.js
+++ b/ionic-core.js
@@ -291,9 +291,9 @@ angular.module('ionic.service.core', [])
 */
 .factory('$ionicUser', [
   '$q',
-  '$ionicCoreSettings',
   '$timeout',
   '$http',
+  '$ionicCoreSettings',
   'persistentStorage',
   '$ionicApp',
 function($q, $timeout, $http, $ionicCoreSettings, persistentStorage, $ionicApp) {


### PR DESCRIPTION
$ionicUser has mismatched order between variable and injection string.
This pull request fixes it.
